### PR TITLE
fix(rn-UseCase): 修复 getLongVersionCode 的 NewApi 调用错误

### DIFF
--- a/android/app/src/main/java/com/novel/rn/settings/usecase/ExportUserDataUseCase.kt
+++ b/android/app/src/main/java/com/novel/rn/settings/usecase/ExportUserDataUseCase.kt
@@ -146,7 +146,14 @@ class ExportUserDataUseCase @Inject constructor(
     private fun getAppVersion(): String {
         return try {
             val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-            "${packageInfo.versionName} (${packageInfo.longVersionCode})"
+            // 根据系统版本，安全地获取版本号
+            val versionCode = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                packageInfo.longVersionCode
+            } else {
+                @Suppress("DEPRECATION") // 忽略旧版 versionCode 的“已过时”警告
+                packageInfo.versionCode.toLong()
+            }
+            "${packageInfo.versionName} ($versionCode)"
         } catch (e: Exception) {
             TimberLogger.e(TAG, "获取应用版本失败", e)
             "Unknown"


### PR DESCRIPTION
修复了在 ExportUserDataUseCase.kt 中因直接调用 getLongVersionCode() 而导致的 Android Lint NewApi 错误。

该方法仅在 API 28 (Android 9) 及以上版本可用，而项目的 minSdkVersion 为 26，这会在低版本设备上导致运行时崩溃。

通过增加版本判断，确保了代码的向后兼容性：

在 API 28 及以上设备上，继续使用 longVersionCode。

在低于 API 28 的设备上，回退到使用旧的 versionCode 属性。

此修改解决了 Lint 错误，使构建得以通过，并消除了在旧设备上的潜在崩溃风险。